### PR TITLE
[macOS] Support option-left/right to skip words

### DIFF
--- a/garglk/glk.h
+++ b/garglk/glk.h
@@ -482,5 +482,7 @@ extern void garglk_set_reversevideo_stream(strid_t str, glui32 reverse);
 #define keycode_Erase               (0xffffef7f)
 #define keycode_MouseWheelUp        (0xffffeffe)
 #define keycode_MouseWheelDown      (0xffffefff)
+#define keycode_SkipWordLeft        (0xfffff000)
+#define keycode_SkipWordRight       (0xfffff001)
 
 #endif /* GLK_H */

--- a/garglk/launchmac.m
+++ b/garglk/launchmac.m
@@ -147,6 +147,8 @@ char *winfilters[] =
 - (IBAction) cut: (id) sender;
 - (IBAction) copy: (id) sender;
 - (IBAction) paste: (id) sender;
+- (void) moveWordBackward: (id) sender;
+- (void) moveWordForward: (id) sender;
 - (IBAction) performZoom: (id) sender;
 - (void) performRefresh: (NSNotification *) notice;
 - (NSString *) openFileDialog: (NSString *) prompt
@@ -212,10 +214,8 @@ static BOOL isTextbufferEvent(NSEvent * evt)
     /* check for arrow keys */
     if ([evt modifierFlags] & NSFunctionKeyMask)
     {
-        /* modified keys for scrolling */
-        if ([evt modifierFlags] & NSCommandKeyMask ||
-            [evt modifierFlags] & NSAlternateKeyMask ||
-            [evt modifierFlags] & NSControlKeyMask)
+        /* alt/option modified key */
+        if ([evt modifierFlags] & NSAlternateKeyMask)
         {
             switch ([evt keyCode])
             {
@@ -227,8 +227,8 @@ static BOOL isTextbufferEvent(NSEvent * evt)
             }
         }
 
-        /* unmodified keys for line editing */
-        else
+        /* command modified key */
+        if ([evt modifierFlags] & NSCommandKeyMask)
         {
             switch ([evt keyCode])
             {
@@ -238,6 +238,16 @@ static BOOL isTextbufferEvent(NSEvent * evt)
                 case NSKEY_UP    : return NO;
                 default: break;
             }
+        }
+
+        /* unmodified key for line editing */
+        switch ([evt keyCode])
+        {
+            case NSKEY_LEFT  : return NO;
+            case NSKEY_RIGHT : return NO;
+            case NSKEY_DOWN  : return NO;
+            case NSKEY_UP    : return NO;
+            default: break;
         }
     }
 
@@ -416,6 +426,34 @@ static BOOL isTextbufferEvent(NSEvent * evt)
                    charactersIgnoringModifiers: @"V"
                                      isARepeat: NO
                                        keyCode: NSKEY_V]];
+}
+
+- (void) moveWordBackward: (id) sender
+{
+    [self sendEvent: [NSEvent keyEventWithType: NSKeyDown
+                                      location: NSZeroPoint
+                                 modifierFlags: NSAlternateKeyMask
+                                     timestamp: NSTimeIntervalSince1970
+                                  windowNumber: [self windowNumber]
+                                       context: [self graphicsContext]
+                                    characters: @""
+                   charactersIgnoringModifiers: @""
+                                     isARepeat: NO
+                                       keyCode: NSKEY_LEFT]];
+}
+
+- (void) moveWordForward: (id) sender
+{
+    [self sendEvent: [NSEvent keyEventWithType: NSKeyDown
+                                      location: NSZeroPoint
+                                 modifierFlags: NSAlternateKeyMask
+                                     timestamp: NSTimeIntervalSince1970
+                                  windowNumber: [self windowNumber]
+                                       context: [self graphicsContext]
+                                    characters: @""
+                   charactersIgnoringModifiers: @""
+                                     isARepeat: NO
+                                       keyCode: NSKEY_RIGHT]];
 }
 
 - (IBAction) performZoom: (id) sender

--- a/garglk/sysmac.m
+++ b/garglk/sysmac.m
@@ -430,10 +430,21 @@ void winkey(NSEvent *evt)
     /* check for arrow keys */
     if ([evt modifierFlags] & NSFunctionKeyMask)
     {
-        /* modified keys for scrolling */
-        if ([evt modifierFlags] & NSCommandKeyMask
-            || [evt modifierFlags] & NSAlternateKeyMask
-            || [evt modifierFlags] & NSControlKeyMask)
+        /* alt/option modified key */
+        if ([evt modifierFlags] & NSAlternateKeyMask)
+        {
+            switch ([evt keyCode])
+            {
+                case NSKEY_LEFT  : gli_input_handle_key(keycode_SkipWordLeft);  return;
+                case NSKEY_RIGHT : gli_input_handle_key(keycode_SkipWordRight); return;
+                case NSKEY_DOWN  : gli_input_handle_key(keycode_PageDown);      return;
+                case NSKEY_UP    : gli_input_handle_key(keycode_PageUp);        return;
+                default: break;
+            }
+        }
+
+        /* command modified key */
+        if ([evt modifierFlags] & NSCommandKeyMask)
         {
             switch ([evt keyCode])
             {
@@ -445,17 +456,14 @@ void winkey(NSEvent *evt)
             }
         }
 
-        /* unmodified keys for line editing */
-        else
+        /* unmodified key for line editing */
+        switch ([evt keyCode])
         {
-            switch ([evt keyCode])
-            {
-                case NSKEY_LEFT  : gli_input_handle_key(keycode_Left);  return;
-                case NSKEY_RIGHT : gli_input_handle_key(keycode_Right); return;
-                case NSKEY_DOWN  : gli_input_handle_key(keycode_Down);  return;
-                case NSKEY_UP    : gli_input_handle_key(keycode_Up);    return;
-                default: break;
-            }
+            case NSKEY_LEFT  : gli_input_handle_key(keycode_Left);  return;
+            case NSKEY_RIGHT : gli_input_handle_key(keycode_Right); return;
+            case NSKEY_DOWN  : gli_input_handle_key(keycode_Down);  return;
+            case NSKEY_UP    : gli_input_handle_key(keycode_Up);    return;
+            default: break;
         }
     }
 

--- a/garglk/wintext.c
+++ b/garglk/wintext.c
@@ -1676,6 +1676,20 @@ void gcmd_buffer_accept_readline(window_t *win, glui32 arg)
             dwin->incurs = dwin->numchars;
             break;
 
+        case keycode_SkipWordLeft:
+            while (dwin->incurs > dwin->infence && dwin->chars[dwin->incurs - 1] == ' ')
+                dwin->incurs--;
+            while (dwin->incurs > dwin->infence && dwin->chars[dwin->incurs - 1] != ' ')
+                dwin->incurs--;
+            break;
+
+        case keycode_SkipWordRight:
+            while (dwin->incurs < dwin->numchars && dwin->chars[dwin->incurs] != ' ')
+                dwin->incurs++;
+            while (dwin->incurs < dwin->numchars && dwin->chars[dwin->incurs] == ' ')
+                dwin->incurs++;
+            break;
+
             /* Delete keys, during line input. */
 
         case keycode_Delete:


### PR DESCRIPTION
Using alt/option modifier instead of control as that is the system-wide
key combination to skip works (control-left/right is used by Mission
Control).